### PR TITLE
Use `Enum.random/1`

### DIFF
--- a/lib/rails.ex
+++ b/lib/rails.ex
@@ -6,7 +6,7 @@ defmodule Rails do
   end
 
   def call(conn, _opts) do
-    rails_penalty = 500..1200 |> Enum.shuffle |> Enum.at(0)
+    rails_penalty = 500..1200 |> Enum.random
     :timer.sleep(rails_penalty)
     conn
   end


### PR DESCRIPTION
We could use a pipe here:

```elixir
500..1200
|> Enum.random
|> :timer.sleep
```

but it feels like the variable name is important so I decided against it.